### PR TITLE
Updating README with permissions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This action can be used to post a dynamic comment on a github PR
 **Required** The value of your GitHub Actions GitHub Token, this is
 usually: `${{ secrets.GITHUB_TOKEN }}`
 Make sure your `GITHUB_TOKEN` has the proper permissions to write on a pull-request.
-Check here[https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token] how to add permissions if necessary.
+Check [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) how to add permissions if necessary.
 
-## Permission example
+## Permissions example
 
 ```yaml
 permissions:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ This action can be used to post a dynamic comment on a github PR
 
 **Required** The value of your GitHub Actions GitHub Token, this is
 usually: `${{ secrets.GITHUB_TOKEN }}`
+Make sure your `GITHUB_TOKEN` has the proper permissions to write on a pull-request.
+Check here[https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token] how to add permissions if necessary.
+
+## Permission example
+
+```yaml
+permissions:
+  checks: read
+  contents: read
+  pull-requests: write
+```
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This action can be used to post a dynamic comment on a github PR
 ### `GITHUB_TOKEN`
 
 **Required** The value of your GitHub Actions GitHub Token, this is
-usually: `${{ secrets.GITHUB_TOKEN }}`
+usually: `${{ secrets.GITHUB_TOKEN }}`.
+
 Make sure your `GITHUB_TOKEN` has the proper permissions to write on a pull-request.
 Check [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) how to add permissions if necessary.
 


### PR DESCRIPTION
I had a issue using the action where I didn’t check the `GITHUB_TOKEN` didn’t have the proper permissions to write on a pull-request.

I guess adding this it will make clear the `GITHUB_TOKEN` permission needs to be updated and it will not write on a pull-request by default.